### PR TITLE
Chunked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # youtube-audio-server changelog
 
+## v2.3.0
+
+### Added
+
+- /cache/[videoId] endpoint: Returns the same stream for requested audio
+  until processing finishes.
+- `/chunk/[videoId]`: Saves mp3 file to disk and returns a stream to it
+  with chunks supports.
+
+## v2.2.0
+
+### Added
+
+- setKey method to allow setting YouTube API key programatically.
+
 ## v2.1.5
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# youtube-audio-server 
+# youtube-audio-server
+
 Easily stream and download audio from YouTube.
 
 [![Build Status](https://travis-ci.org/codealchemist/youtube-audio-server.svg?branch=master)](https://travis-ci.org/codealchemist/youtube-audio-server)
@@ -6,6 +7,7 @@ Easily stream and download audio from YouTube.
 [![JavaScript Style Guide](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
 ## Install
+
 `npm install -g youtube-audio-server`
 
 Or:
@@ -21,7 +23,7 @@ Your Google App needs to have the YouTube API enabled.
 
 Login at https://console.cloud.google.com to get this data.
 
-To support this features, *YAS* should be started like this:
+To support this features, _YAS_ should be started like this:
 
 `KEY=[YOUR-APP-KEY] yas`
 
@@ -40,11 +42,13 @@ To be able to run **YAS** on Heroku you need to install the **ffmpeg** buildpack
 `heroku buildpacks:add https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest.git`
 
 ## Command line usage
+
 ### REST API
 
 Start **YAS** with `yas`.
 
 #### Audio stream
+
 Just hit the server passing a YouTube video id, like:
 
 http://yourServerAddress:port/[videoId]
@@ -57,15 +61,28 @@ This will stream the requested video's audio.
 
 You can play it on an HTML5 audio tag or however you like.
 
+**Other endpoints:**
+
+- `/cache/[videoId]`: Returns the same stream for requested audio
+  until processing finishes. Useful to avoid multiple requests from creating
+  zombie instances of ffmpeg. This happens in Chrome, which makes a document
+  request first and then a media request. The document request makes ffmpeg
+  to start processing but never finishes.
+  Firefox properly loads the audio with just one request and allows seeking.
+- `/chunk/[videoId]`: Saves mp3 file to disk and returns a stream to it.
+  This allows data chunks to be sent to the client, which will be able to seek
+  across the file. Enables Chrome and VLC, for example, to do seeking.
+
 #### Get metadata
+
 Use: http://yourServerAddress:port/get/[videoId]
 
 #### Search
+
 Use: http://yourServerAddress:port/search/[query]/[[pageToken]]
 
 To navigate pages you need to use `pageToken` which is provided in the results on the
 root level property `nextPageToken`.
-
 
 ### Change port:
 
@@ -75,8 +92,8 @@ You can easily change it by starting **YAS** like:
 
 `PORT=8080 yas`
 
-
 ### Download audio
+
 **YAS** can also be used to easliy download audio.
 
 In this mode, the server is not started.
@@ -86,14 +103,15 @@ In this mode, the server is not started.
 `yas --id [youtube-video-id] [--file [./sample.mp3]]`
 
 **Examples:**
+
 ```
 yas --id 2zYDMN4h2hY --file ~/Downloads/Music/sample.mp3
 yas --id 2zYDMN4h2hY
 ```
 
-**NOTE:** 
+**NOTE:**
 
-FILE defaults to `./youtube-audio.mp3` when not set.
+FILE defaults to `./[videoId].mp3` when not set.
 
 **Alternative method:**
 
@@ -102,11 +120,9 @@ you can do this:
 
 `curl [your-server-url]/[youtube-video-id] > sample.mp3`
 
-
 ## Programatic usage
 
 Yeah, you can also include **YAS** in your project and use it programatically!
-
 
 ### REST API
 
@@ -120,7 +136,6 @@ yas.listen(port, () => {
 })
 
 ```
-
 
 ### Download audio
 
@@ -140,7 +155,6 @@ yas.downloader
   .download({id, file})
 ```
 
-
 ### Get video metadata
 
 ```
@@ -150,7 +164,6 @@ yas.get('HQmmM_qwG4k', (err, data) => {
   console.log('GOT METADATA for HQmmM_qwG4k:', data || err)
 })
 ```
-
 
 ### Search
 
@@ -169,25 +182,23 @@ yas.search({
 To navigate pages you need to use `pageToken` which is provided in the results on the
 root level property `data.nextPageToken`.
 
-
 ## Dependencies
-The key dependency for *youtube-audio-server* is 
-[youtube-audio-stream](https://github.com/JamesKyburz/youtube-audio-stream), 
+
+The key dependency for _youtube-audio-server_ is
+[youtube-audio-stream](https://github.com/JamesKyburz/youtube-audio-stream),
 which depends on `ffmpeg`, which must be installed at system level, it's not
 a node dependency!
-
 
 ### Install ffmpeg on OSX
 
 `brew install ffmpeg`
 
-
 ### Install ffmpeg on Debian Linux
 
 `sudo apt-get install ffmpeg`
 
-
 ## Testing
+
 Just open the URL of your server instance without specifing a video id.
 
 This will load a test page with an HTML5 audio element that will stream a test video id.
@@ -200,6 +211,5 @@ You can open the shown URL to test the REST API works as expected.
 
 You can also use `npm run test-focus` to concentrate on one linting
 issue at a time with the help of [standard-focus](https://www.npmjs.com/package/standard-focus).
-
 
 Enjoy!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,7 +1349,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -1357,7 +1357,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "~2.1.11",
         "negotiator": "0.6.1"
       }
     },
@@ -25,7 +25,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -42,8 +42,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -76,7 +76,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-flatten": {
@@ -90,7 +90,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -120,7 +120,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "aws-sign2": {
@@ -134,9 +134,9 @@
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
+        "chalk": "^1.1.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "balanced-match": {
@@ -149,7 +149,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.26"
       },
       "dependencies": {
         "isarray": {
@@ -162,10 +162,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -180,7 +180,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -188,7 +188,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
       "requires": {
-        "balanced-match": "0.4.2",
+        "balanced-match": "^0.4.1",
         "concat-map": "0.0.1"
       }
     },
@@ -209,7 +209,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -229,11 +229,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "circular-json": {
@@ -248,7 +248,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -263,9 +263,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clivas": {
@@ -310,9 +310,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.9",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "content-disposition": {
@@ -345,7 +345,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "ctype": {
@@ -364,7 +364,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.15"
+        "es5-ext": "^0.10.9"
       }
     },
     "debug": {
@@ -404,12 +404,12 @@
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "1.0.0",
-        "glob": "7.1.1",
-        "ignore": "3.3.0",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.6",
-        "uniq": "1.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
       }
     },
     "del": {
@@ -418,13 +418,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -448,8 +448,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "ee-first": {
@@ -468,7 +468,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -477,8 +477,8 @@
       "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "2",
+        "es6-symbol": "~3.1"
       }
     },
     "es6-iterator": {
@@ -487,9 +487,9 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-symbol": "^3.1"
       }
     },
     "es6-map": {
@@ -498,12 +498,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -512,11 +512,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15",
-        "es6-iterator": "2.0.1",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -525,8 +525,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -535,10 +535,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -558,10 +558,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -570,40 +570,40 @@
       "integrity": "sha1-yaEOi/bp1lZRIEd4xQM0Hx6sPOc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.1",
-        "doctrine": "1.5.0",
-        "escope": "3.6.0",
-        "espree": "3.4.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.1",
-        "globals": "9.17.0",
-        "ignore": "3.3.0",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.7",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.2.2",
+        "escope": "^3.6.0",
+        "espree": "^3.3.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.2.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       }
     },
     "eslint-config-standard": {
@@ -630,8 +630,8 @@
       "integrity": "sha1-Gvlq6lRYVoJRV9l8G1DVqPtkpac=",
       "dev": true,
       "requires": {
-        "doctrine": "1.5.0",
-        "jsx-ast-utils": "1.4.1"
+        "doctrine": "^1.2.2",
+        "jsx-ast-utils": "^1.3.3"
       }
     },
     "eslint-plugin-standard": {
@@ -646,8 +646,8 @@
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
       "requires": {
-        "acorn": "5.0.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.0.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -662,8 +662,8 @@
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
       "requires": {
-        "estraverse": "4.1.1",
-        "object-assign": "4.1.1"
+        "estraverse": "~4.1.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "estraverse": {
@@ -697,8 +697,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.15"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "exit-hook": {
@@ -712,34 +712,34 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.2.tgz",
       "integrity": "sha1-rxB/wUhQRFfy3Kmm8lcdcSm5ezU=",
       "requires": {
-        "accepts": "1.3.3",
+        "accepts": "~1.3.3",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "~1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.1",
-        "depd": "1.1.0",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.2",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
+        "proxy-addr": "~1.1.3",
         "qs": "6.4.0",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "send": "0.15.1",
         "serve-static": "1.12.1",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
         "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "vary": "~1.1.0"
       }
     },
     "express-no-favicons": {
@@ -764,8 +764,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -774,8 +774,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "finalhandler": {
@@ -784,12 +784,12 @@
       "integrity": "sha1-0ONvnbxVfy3hRCPfYmGInp1gyTo=",
       "requires": {
         "debug": "2.6.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -819,10 +819,10 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "fluent-ffmpeg": {
@@ -830,8 +830,8 @@
       "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
       "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
       "requires": {
-        "async": "2.6.0",
-        "which": "1.3.0"
+        "async": ">=0.2.9",
+        "which": "^1.1.1"
       }
     },
     "forever-agent": {
@@ -844,9 +844,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
       "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime-types": "2.0.14"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime-types": "~2.0.3"
       },
       "dependencies": {
         "async": {
@@ -864,7 +864,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         }
       }
@@ -890,7 +890,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.1.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -905,7 +905,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -925,12 +925,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -945,12 +945,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "globule": {
@@ -959,9 +959,9 @@
       "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1",
-        "lodash": "4.16.6",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.16.4",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "lodash": {
@@ -984,7 +984,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "hawk": {
@@ -992,10 +992,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
       "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -1009,8 +1009,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -1032,7 +1032,7 @@
         "depd": "1.1.0",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "http-signature": {
@@ -1041,7 +1041,7 @@
       "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
       "requires": {
         "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
+        "assert-plus": "^0.1.5",
         "ctype": "0.5.3"
       }
     },
@@ -1067,8 +1067,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1082,19 +1082,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "interpret": {
@@ -1126,7 +1126,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -1135,7 +1135,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -1144,10 +1144,10 @@
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-path-cwd": {
@@ -1162,7 +1162,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -1171,7 +1171,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-property": {
@@ -1186,7 +1186,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-utf8": {
@@ -1222,8 +1222,8 @@
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "argparse": "^1.0.7",
+        "esprima": "^3.1.1"
       }
     },
     "json-stable-stringify": {
@@ -1232,7 +1232,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1264,7 +1264,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -1273,8 +1273,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "line-replace": {
@@ -1293,7 +1293,7 @@
       "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.2.2.tgz",
       "integrity": "sha512-R/xWLXBtVr0m9sPruRL4p9uO01JyHxhcQ4nhqQhVgyT802OZyVW+dn+fWHvTnbfE6YMLc65TksZZut+Mh2OVMQ==",
       "requires": {
-        "miniget": "1.2.0"
+        "miniget": "^1.1.0"
       }
     },
     "media-typer": {
@@ -1326,7 +1326,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "~1.27.0"
       }
     },
     "miniget": {
@@ -1339,7 +1339,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.7"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1399,10 +1399,10 @@
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.4.2",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "number-is-nan": {
@@ -1435,7 +1435,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1450,12 +1450,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -1476,7 +1476,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -1524,7 +1524,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-config": {
@@ -1533,9 +1533,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.0.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkginfo": {
@@ -1571,11 +1571,11 @@
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
       "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
       "requires": {
-        "pkginfo": "0.4.0",
-        "read": "1.0.7",
-        "revalidator": "0.1.8",
-        "utile": "0.2.1",
-        "winston": "0.8.3"
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.2.x",
+        "winston": "0.8.x"
       }
     },
     "proxy-addr": {
@@ -1583,7 +1583,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
       "requires": {
-        "forwarded": "0.1.0",
+        "forwarded": "~0.1.0",
         "ipaddr.js": "1.3.0"
       }
     },
@@ -1607,7 +1607,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "0.0.5"
+        "mute-stream": "~0.0.4"
       }
     },
     "readable-stream": {
@@ -1615,13 +1615,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
       "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.0",
-        "util-deprecate": "1.0.2"
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -1630,8 +1630,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -1641,7 +1641,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "^1.1.6"
       }
     },
     "request": {
@@ -1649,23 +1649,23 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
       "integrity": "sha1-GAo66St7Y5gC5PlUXdj83rcddgw=",
       "requires": {
-        "aws-sign2": "0.5.0",
-        "bl": "0.9.5",
-        "caseless": "0.9.0",
-        "combined-stream": "0.0.7",
-        "forever-agent": "0.5.2",
-        "form-data": "0.2.0",
-        "hawk": "2.3.1",
-        "http-signature": "0.10.1",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.0.14",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.6.0",
-        "qs": "2.3.3",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.4.3"
+        "aws-sign2": "~0.5.0",
+        "bl": "~0.9.0",
+        "caseless": "~0.9.0",
+        "combined-stream": "~0.0.5",
+        "forever-agent": "~0.5.0",
+        "form-data": "~0.2.0",
+        "hawk": "~2.3.0",
+        "http-signature": "~0.10.0",
+        "isstream": "~0.1.1",
+        "json-stringify-safe": "~5.0.0",
+        "mime-types": "~2.0.1",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.6.0",
+        "qs": "~2.3.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.4.0"
       },
       "dependencies": {
         "mime-db": {
@@ -1678,7 +1678,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         },
         "qs": {
@@ -1706,8 +1706,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -1716,7 +1716,7 @@
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -1731,8 +1731,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "revalidator": {
@@ -1745,7 +1745,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
-        "glob": "7.1.1"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -1754,7 +1754,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
@@ -1786,18 +1786,18 @@
       "integrity": "sha1-igI1TCbm9cynAAZfXwzeupDse18=",
       "requires": {
         "debug": "2.6.1",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "1.6.1",
+        "http-errors": "~1.6.1",
         "mime": "1.3.4",
         "ms": "0.7.2",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       }
     },
     "serve-static": {
@@ -1805,9 +1805,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz",
       "integrity": "sha1-dEOpZePO1kes61Y5+ga/TRu+ADk=",
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
         "send": "0.15.1"
       }
     },
@@ -1828,9 +1828,9 @@
       "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "slice-ansi": {
@@ -1844,7 +1844,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "spdx-correct": {
@@ -1853,7 +1853,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -1885,13 +1885,13 @@
       "integrity": "sha1-Y1Eyvnv7VnwpIQBfMPnjUOR1Kq0=",
       "dev": true,
       "requires": {
-        "eslint": "3.10.2",
+        "eslint": "~3.10.2",
         "eslint-config-standard": "6.2.1",
         "eslint-config-standard-jsx": "3.2.0",
-        "eslint-plugin-promise": "3.4.2",
-        "eslint-plugin-react": "6.7.1",
-        "eslint-plugin-standard": "2.0.1",
-        "standard-engine": "5.2.0"
+        "eslint-plugin-promise": "~3.4.0",
+        "eslint-plugin-react": "~6.7.1",
+        "eslint-plugin-standard": "~2.0.1",
+        "standard-engine": "~5.2.0"
       }
     },
     "standard-engine": {
@@ -1900,12 +1900,12 @@
       "integrity": "sha1-QAZgrlrM6K/U22D/IhSpGQrXkKM=",
       "dev": true,
       "requires": {
-        "deglob": "2.1.0",
-        "find-root": "1.0.0",
-        "get-stdin": "5.0.1",
-        "home-or-tmp": "2.0.0",
-        "minimist": "1.2.0",
-        "pkg-config": "1.1.1"
+        "deglob": "^2.0.0",
+        "find-root": "^1.0.0",
+        "get-stdin": "^5.0.1",
+        "home-or-tmp": "^2.0.0",
+        "minimist": "^1.1.0",
+        "pkg-config": "^1.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -1922,11 +1922,11 @@
       "integrity": "sha1-8vE7a16Q0iPVoe7YK09pt+hd8Gk=",
       "dev": true,
       "requires": {
-        "clivas": "0.2.0",
-        "gaze": "1.1.2",
-        "line-replace": "1.0.2",
-        "standard": "8.6.0",
-        "yargs": "6.6.0"
+        "clivas": "^0.2.0",
+        "gaze": "^1.1.2",
+        "line-replace": "^1.0.1",
+        "standard": "^8.6.0",
+        "yargs": "^6.6.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1941,8 +1941,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -1951,11 +1951,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -1964,7 +1964,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-exists": {
@@ -1973,7 +1973,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -1982,9 +1982,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1993,9 +1993,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.8",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -2004,8 +2004,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -2014,7 +2014,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -2029,19 +2029,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         },
         "yargs-parser": {
@@ -2050,7 +2050,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -2066,9 +2066,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -2076,7 +2076,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
       "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
       "requires": {
-        "buffer-shims": "1.0.0"
+        "buffer-shims": "~1.0.0"
       }
     },
     "stringstream": {
@@ -2090,7 +2090,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -2117,12 +2117,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2137,8 +2137,8 @@
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -2160,8 +2160,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.2.9",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "tough-cookie": {
@@ -2169,7 +2169,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tryit": {
@@ -2189,7 +2189,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -2198,7 +2198,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -2224,7 +2224,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -2237,12 +2237,12 @@
       "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
       "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
       "requires": {
-        "async": "0.2.10",
-        "deep-equal": "1.0.1",
-        "i": "0.3.5",
-        "mkdirp": "0.5.1",
-        "ncp": "0.4.2",
-        "rimraf": "2.6.1"
+        "async": "~0.2.9",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.4.x",
+        "rimraf": "2.x.x"
       },
       "dependencies": {
         "async": {
@@ -2263,8 +2263,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -2277,7 +2277,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "winston": {
@@ -2285,13 +2285,13 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
       "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
       "requires": {
-        "async": "0.2.10",
-        "colors": "0.6.2",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "pkginfo": "0.3.1",
-        "stack-trace": "0.0.9"
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -2323,8 +2323,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -2338,7 +2338,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xtend": {
@@ -2367,10 +2367,10 @@
       "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-0.20.2.tgz",
       "integrity": "sha512-7AAIdhVRJgS3HulFCdT4C4G8FpeKouFinMCa8YA2cvKmEjXoIiNcMJmtnOI1VJil+l57K1Ly4MzEKlvR6H7C0g==",
       "requires": {
-        "html-entities": "1.2.1",
-        "m3u8stream": "0.2.2",
-        "miniget": "1.2.0",
-        "sax": "1.2.4"
+        "html-entities": "^1.1.3",
+        "m3u8stream": "^0.2.1",
+        "miniget": "^1.1.0",
+        "sax": "^1.1.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-audio-server",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-audio-server",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Easily stream and download audio from YouTube.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-no-favicons": "0.0.1",
     "fluent-ffmpeg": "^2.1.2",
     "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "through2": "^2.0.3",
     "youtube-node": "^1.3.0",
     "ytdl-core": "^0.20.2"

--- a/src/index.js
+++ b/src/index.js
@@ -14,11 +14,11 @@ function listen (port, callback = () => {}) {
     res.sendFile(file)
   })
 
-  app.get('/chunked/:videoId', (req, res) => {
+  app.get('/chunk/:videoId', (req, res) => {
     const videoId = req.params.videoId
 
     try {
-      youtube.download({id: videoId}, (err, {id, file}) => {
+      youtube.download({ id: videoId }, (err, { id, file }) => {
         if (err) return res.sendStatus(500, err)
         res.sendFile(file)
       })
@@ -30,10 +30,20 @@ function listen (port, callback = () => {}) {
 
   app.get('/:videoId', (req, res) => {
     const videoId = req.params.videoId
-    const useCache = (req.query.cache !== undefined)
 
     try {
-      youtube.stream(videoId, useCache).pipe(res)
+      youtube.stream(videoId).pipe(res)
+    } catch (e) {
+      console.error(e)
+      res.sendStatus(500, e)
+    }
+  })
+
+  app.get('/cache/:videoId', (req, res) => {
+    const videoId = req.params.videoId
+
+    try {
+      youtube.stream(videoId, true).pipe(res)
     } catch (e) {
       console.error(e)
       res.sendStatus(500, e)

--- a/src/index.js
+++ b/src/index.js
@@ -14,11 +14,26 @@ function listen (port, callback = () => {}) {
     res.sendFile(file)
   })
 
-  app.get('/:videoId', (req, res) => {
+  app.get('/chunked/:videoId', (req, res) => {
     const videoId = req.params.videoId
 
     try {
-      youtube.stream(videoId).pipe(res)
+      youtube.download({id: videoId}, (err, {id, file}) => {
+        if (err) return res.sendStatus(500, err)
+        res.sendFile(file)
+      })
+    } catch (e) {
+      console.error(e)
+      res.sendStatus(500, e)
+    }
+  })
+
+  app.get('/:videoId', (req, res) => {
+    const videoId = req.params.videoId
+    const useCache = (req.query.cache !== undefined)
+
+    try {
+      youtube.stream(videoId, useCache).pipe(res)
     } catch (e) {
       console.error(e)
       res.sendStatus(500, e)

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -26,7 +26,6 @@ class YouTube {
   streamDownloaded (id, callback) {
     const video = ytdl(id)
     const ffmpeg = new Ffmpeg(video)
-    const stream = through2()
     let sent = false
 
     try {

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -1,12 +1,17 @@
 const fs = require('fs')
+const path = require('path')
 const ytdl = require('ytdl-core')
 const YtNode = require('youtube-node')
 const through2 = require('through2')
 const Ffmpeg = require('fluent-ffmpeg')
+const cache = {}
 
 class YouTube {
   constructor () {
     this.pageSize = 10
+    this.tempFolder = path.resolve(__dirname, '../temp-audio')
+    console.log('TEMP AUDIO FOLDER:', this.tempFolder)
+    // TODO: mkdirp
 
     const envApiKey = process.env.KEY
     if (envApiKey) this.setKey(envApiKey)
@@ -17,21 +22,58 @@ class YouTube {
     this.ytNode.setKey(apiKey)
   }
 
-  stream (id) {
+  streamDownloaded (id, callback) {
+    const video = ytdl(id)
+    const ffmpeg = new Ffmpeg(video)
+    const stream = through2()
+    let sent = false
+
+    try {
+      const file = `${this.tempFolder}/${id}.mp3`
+      ffmpeg
+        .format('mp3')
+        .on('end', () => {
+          ffmpeg.kill()
+        })
+        .on('data', () => {
+          if (sent) return
+          sent = true
+          callback(fs.createReadStream(file))
+        })
+        .save(file)
+    } catch (e) {
+      throw e
+    }
+  }
+
+  stream (id, useCache) {
+    if (useCache) {
+      const cached = cache[id]
+      if (cached) return cached
+    }
+
     const video = ytdl(id)
     const ffmpeg = new Ffmpeg(video)
     const stream = through2()
 
     try {
-      ffmpeg.format('mp3').pipe(stream)
+      ffmpeg
+        .format('mp3')
+        .on('end', () => {
+          cache[id] = null
+          ffmpeg.kill()
+        })
+        .pipe(stream, { end: true })
 
+      cache[id] = stream
       return stream
     } catch (e) {
       throw e
     }
   }
 
-  download ({ id, file = './youtube-audio.mp3' }, callback) {
+  download ({ id, file }, callback) {
+    file = file || `${this.tempFolder}/${id}.mp3`
     const fileWriter = fs.createWriteStream(file)
 
     try {

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const mkdirp = require('mkdirp')
 const ytdl = require('ytdl-core')
 const YtNode = require('youtube-node')
 const through2 = require('through2')
@@ -11,7 +12,7 @@ class YouTube {
     this.pageSize = 10
     this.tempFolder = path.resolve(__dirname, '../temp-audio')
     console.log('TEMP AUDIO FOLDER:', this.tempFolder)
-    // TODO: mkdirp
+    mkdirp(this.tempFolder) // Create temp folder if it doesn't exist.
 
     const envApiKey = process.env.KEY
     if (envApiKey) this.setKey(envApiKey)
@@ -63,7 +64,10 @@ class YouTube {
           cache[id] = null
           ffmpeg.kill()
         })
-        .pipe(stream, { end: true })
+        .pipe(
+          stream,
+          { end: true }
+        )
 
       cache[id] = stream
       return stream


### PR DESCRIPTION
Added new endpoints to support chunked response and to avoid ffmpeg zombie processes:
- `/cache/[videoId]`: Returns the same stream for requested audio
  until processing finishes. Useful to avoid multiple requests from creating
  zombie instances of ffmpeg. This happens in Chrome, which makes a document
  request first and then a media request. The document request makes ffmpeg
  to start processing but never finishes.
  Firefox properly loads the audio with just one request and allows seeking.
- `/chunk/[videoId]`: Saves mp3 file to disk and returns a stream to it.
  This allows data chunks to be sent to the client, which will be able to seek
  across the file. Enables Chrome and VLC, for example, to do seeking.