### PR TITLE
Metadata callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # youtube-audio-server changelog
 
+## v2.7.0
+
+### Added
+
+- `onMetadata` callback for `downloader`
+- Returning `filename` on `onSuccess` response
+
+## v2.6.1
+
+### Fixed
+
+- Avoid saving empty metadata
+
+## v2.6.0
+
+### Added
+
+- metadata support
+
 ## v2.3.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "youtube-audio-server",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-audio-server",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Easily stream and download audio from YouTube.",
   "main": "src/index.js",
   "scripts": {

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -26,16 +26,17 @@ class Downloader {
         id,
         file,
         useCache: c || cache,
-        addMetadata: m || metadata
+        addMetadata: m || metadata,
+        onMetadata: this.onMetadataCallback
       },
-      (err, data) => {
-        if (err) {
-          this.handleError({ id, file, error: err.message || err })
+      (error, data) => {
+        if (error) {
+          this.handleError({ id, file, error })
           return
         }
 
         if (typeof this.onSuccessCallback === 'function') {
-          this.onSuccessCallback({ id, file })
+          this.onSuccessCallback(data)
         }
       }
     )
@@ -50,6 +51,11 @@ class Downloader {
 
   onError (callback) {
     if (typeof callback === 'function') this.onErrorCallback = callback
+    return this
+  }
+
+  onMetadata (callback) {
+    if (typeof callback === 'function') this.onMetadataCallback = callback
     return this
   }
 }


### PR DESCRIPTION
# Changes

- `onMetadata` callback for `downloader`
- Returning `filename` on `onSuccess` response
- Logging error object on downloader `handleError`
- Bumped minor