### PR TITLE
Fix Server Crash with "Output file #0 does not contain any stream" Error for Certain Videos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "youtube-audio-server",
       "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
@@ -19,16 +20,13 @@
         "sanitize-filename": "^1.6.3",
         "through2": "^2.0.3",
         "youtube-node": "^1.3.3",
-        "ytdl-core": "^4.9.1"
+        "ytdl-core": "^4.11.0"
       },
       "bin": {
         "yas": "src/bin.js"
       },
       "devDependencies": {
         "standard-focus": "^1.1.2"
-      },
-      "engines": {
-        "node": "8.*"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -2400,15 +2398,15 @@
       }
     },
     "node_modules/m3u8stream": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.4.tgz",
-      "integrity": "sha512-sco80Db+30RvcaIOndenX6E6oQNgTiBKeJbFPc+yDXwPQIkryfboEbCvXPlBRq3mQTCVPQO93TDVlfRwqpD35w==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
       "dependencies": {
-        "miniget": "^4.0.0",
+        "miniget": "^4.2.2",
         "sax": "^1.2.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -2499,11 +2497,11 @@
       }
     },
     "node_modules/miniget": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.1.tgz",
-      "integrity": "sha512-O/DduzDR6f+oDtVype9S/Qu5hhnx73EDYGyZKwU/qN82lehFZdfhoa4DT51SpsO+8epYrB3gcRmws56ROfTIoQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.2.tgz",
+      "integrity": "sha512-a7voNL1N5lDMxvTMExOkg+Fq89jM2vY8pAi9ZEWzZtfNmdfP6RXkvUtFnCAXoCv2T9k1v/fUJVaAEuepGcvLYA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -4293,16 +4291,16 @@
       }
     },
     "node_modules/ytdl-core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.9.1.tgz",
-      "integrity": "sha512-6Jbp5RDhUEozlaJQAR+l8oV8AHsx3WUXxSyPxzE6wOIAaLql7Hjiy0ZM58wZoyj1YEenlEPjEqcJIjKYKxvHtQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
+      "integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
       "dependencies": {
-        "m3u8stream": "^0.8.3",
-        "miniget": "^4.0.0",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.2",
         "sax": "^1.1.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     }
   },
@@ -6217,11 +6215,11 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "m3u8stream": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.4.tgz",
-      "integrity": "sha512-sco80Db+30RvcaIOndenX6E6oQNgTiBKeJbFPc+yDXwPQIkryfboEbCvXPlBRq3mQTCVPQO93TDVlfRwqpD35w==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
       "requires": {
-        "miniget": "^4.0.0",
+        "miniget": "^4.2.2",
         "sax": "^1.2.4"
       }
     },
@@ -6285,9 +6283,9 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "miniget": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.1.tgz",
-      "integrity": "sha512-O/DduzDR6f+oDtVype9S/Qu5hhnx73EDYGyZKwU/qN82lehFZdfhoa4DT51SpsO+8epYrB3gcRmws56ROfTIoQ=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.2.tgz",
+      "integrity": "sha512-a7voNL1N5lDMxvTMExOkg+Fq89jM2vY8pAi9ZEWzZtfNmdfP6RXkvUtFnCAXoCv2T9k1v/fUJVaAEuepGcvLYA=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7733,12 +7731,12 @@
       }
     },
     "ytdl-core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.9.1.tgz",
-      "integrity": "sha512-6Jbp5RDhUEozlaJQAR+l8oV8AHsx3WUXxSyPxzE6wOIAaLql7Hjiy0ZM58wZoyj1YEenlEPjEqcJIjKYKxvHtQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
+      "integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
       "requires": {
-        "m3u8stream": "^0.8.3",
-        "miniget": "^4.0.0",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.2",
         "sax": "^1.1.3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "sanitize-filename": "^1.6.3",
     "through2": "^2.0.3",
     "youtube-node": "^1.3.3",
-    "ytdl-core": "^4.9.1"
+    "ytdl-core": "^4.11.0"
   },
   "devDependencies": {
     "standard-focus": "^1.1.2"

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -159,7 +159,7 @@ class YouTube {
       if (cached) return cached
     }
 
-    const video = ytdl(id)
+    const video = ytdl(id, { quality: 'highestaudio' })
     const ffmpeg = new Ffmpeg(video)
     const stream = through2()
 


### PR DESCRIPTION
The current release of YouTube Audio Server has an issue that causes it to crash with the following error when attempting to play certain videos:

```javascript
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: ffmpeg exited with code 1: Output #0, mp3, to 'pipe:1':
Output file #0 does not contain any stream

    at ChildProcess.<anonymous> (C:\youtube-audio-server\node_modules\fluent-ffmpeg\lib\processor.js:182:22)
    at ChildProcess.emit (node:events:527:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:291:12)
Emitted 'error' event on FfmpegCommand instance at:
    at emitEnd (C:\youtube-audio-server\node_modules\fluent-ffmpeg\lib\processor.js:424:16)
    at endCB (C:\youtube-audio-server\node_modules\fluent-ffmpeg\lib\processor.js:544:13)
    at handleExit (C:\youtube-audio-server\node_modules\fluent-ffmpeg\lib\processor.js:170:11)
    at ChildProcess.<anonymous> (C:\youtube-audio-server\node_modules\fluent-ffmpeg\lib\processor.js:182:11)
    at ChildProcess.emit (node:events:527:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:291:12)
```

To reproduce this issue, try testing with this video: https://www.youtube.com/watch?v=awjBLm41xJI

This pull request fixes the issue. Additionally, the `ytdl-core` version in `package.json` has been updated  from 4.9.1 to 4.11.0.