### PR TITLE
fix audio file naming order of operations

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -202,9 +202,9 @@ class YouTube {
 
     // Without metadata.
     file =
-      file || id.match(/^http.*/)
+      file || (id.match(/^http.*/)
         ? `${this.audioFolder}/youtube-audio.mp3`
-        : `${this.audioFolder}/${id}.mp3`
+        : `${this.audioFolder}/${id}.mp3`)
     spinner.start('Save audio')
     try {
       await this.writeFile({


### PR DESCRIPTION
given 
```
let id = "dQw4w9WgXcQ"
let file = "rick.mp3"
```

```
file = file || (id.match(/http.*/) ? "youtube-audio.mp3" : `${id}.mp3`)
console.log(file)
```
prints `rick.mp3`, while
```
file = file || id.match(/http.*/) ? "youtube-audio.mp3" : `${id}.mp3`
console.log(file)
```
prints `youtube-audio.mp3`